### PR TITLE
Can now set multiple cohorts as capstone season enabled

### DIFF
--- a/src/components/cohorts/CohortDetails.js
+++ b/src/components/cohorts/CohortDetails.js
@@ -227,17 +227,27 @@ export const CohortDetails = () => {
 
                                 <h2>Capstone Season</h2>
                                 <div className="capstoneToggle">
-                                    <input defaultChecked={capstoneSeason.active}
+                                    <input checked={capstoneSeason.includes(activeCohortDetails.id)}
                                         onChange={(evt) => {
                                             evt.target.ariaChecked = evt.target.checked
 
-                                            const seasonObject = {
-                                                id: activeCohortDetails.id,
-                                                active: evt.target.checked
+                                            const localStorageSeasons = localStorage.getItem("capstoneSeason")
+                                            const cohortsInCapstoneSeason = localStorageSeasons
+                                                    ? new Set([...JSON.parse(localStorageSeasons)])
+                                                    : new Set()
+
+                                            if (evt.target.checked) {
+                                                cohortsInCapstoneSeason.add(activeCohortDetails.id)
                                             }
-                                            setCapstoneSeason(seasonObject)
-                                            localStorage.setItem("capstoneSeason", JSON.stringify(seasonObject))
-                                        }} id="toggle" className="toggle" type="checkbox" role="switch" name="toggle" value="on" />
+                                            else {
+                                                cohortsInCapstoneSeason.delete(activeCohortDetails.id)
+                                            }
+
+                                            const capstoneSeasonCohorts = Array.from(cohortsInCapstoneSeason)
+                                            setCapstoneSeason(capstoneSeasonCohorts)
+                                            localStorage.setItem("capstoneSeason", JSON.stringify(capstoneSeasonCohorts))
+
+                                        }} id="toggle" className="toggle" type="checkbox" role="switch" name="toggle" />
                                     <label htmlFor="toggle" className="slot">
                                         <span className="slot__label">OFF</span>
                                         <span className="slot__label">ON</span>

--- a/src/components/course/CourseProvider.js
+++ b/src/components/course/CourseProvider.js
@@ -8,7 +8,7 @@ export const CourseProvider = (props) => {
     const [courses, setCourses] = useState([])
     const [objectives, setObjectives] = useState([])
     const [activeCourse, setActiveCourse] = useState({})
-    const [capstoneSeason, setCapstoneSeason] = useState({ id: 0, active: false })
+    const [capstoneSeason, setCapstoneSeason] = useState([])
 
     useEffect(() => {
         const seasonObject = JSON.parse(localStorage.getItem("capstoneSeason"))

--- a/src/components/dashboard/Dashboard.js
+++ b/src/components/dashboard/Dashboard.js
@@ -29,8 +29,8 @@ export const Dashboard = () => {
     const history = useHistory()
 
     useEffect(() => {
-        if (capstoneSeason.active && capstoneSeason.id === activeCohort) {
-            if (cohortStudents.length > 0 && "id" in activeCourse) {
+        if (capstoneSeason.includes(activeCohort)) {
+            if (cohortStudents.length > 0) {
                 const mvpReached = cohortStudents.reduce((count, student) => {
                     return student.proposals.find(p => p?.status === "MVP" && p.course_name === activeCourse.name) ? ++count : count
                 }, 0)
@@ -41,7 +41,7 @@ export const Dashboard = () => {
     }, [cohortStudents, activeCourse])
 
     const mvpCountBadge = () => {
-        if (capstoneSeason.active && capstoneSeason.id === activeCohort) {
+        if (capstoneSeason.includes(activeCohort)) {
             return <section className="capstonePercent">
                 <div>{mvps} / {cohortStudents.length} @ MVP</div>
             </section>
@@ -61,7 +61,7 @@ export const Dashboard = () => {
 
             </section>
             {
-                capstoneSeason.active && capstoneSeason.id === activeCohort
+                capstoneSeason.includes(activeCohort)
                     ? <StudentCapstoneList searchTerms={searchTerms} />
                     : <><StudentCardList searchTerms={searchTerms} /><Shortcuts /></>
             }


### PR DESCRIPTION
## Overview

This branch was to enable an instructor to mark multiple cohorts to be in capstone season and the the dashboard view default to the correct state. Previously, only one cohort could be marked in capstone season, forcing the instructor to go to the cohort details and constantly toggle on/off when doing MVP review for different cohorts.

## Steps to Test

1. Switch to the `feature/multi-capstone-season` branch.
2. Authenticate the client with Github
3. Pick any random active cohort
4. Toggle capstone season to "On"
5. Pick another cohort
6. Toggle capstone season to "On"
7. Go to main dashboard
8. Click on both cohorts to verify that the capstone view is active for both
9. Click on another cohort that hasn't been set to capstone season and verify that the standard view is active