### PR TITLE
Handle dropping a student on the assessment

### DIFF
--- a/src/components/cohorts/StudentCardList.js
+++ b/src/components/cohorts/StudentCardList.js
@@ -266,7 +266,19 @@ export const StudentCardList = ({ searchTerms }) => {
             new Toast("Self-assessment for this book not marked as reviewed and complete.", Toast.TYPE_WARNING, Toast.TIME_NORMAL);
         }
         else {
-            assignStudentToProject(rawStudent, project)
+            // Assign to assessment
+            if (project.index === 99) {
+                if (rawStudent.assessment_status === 0) {
+                    setStudentCurrentAssessment(rawStudent)
+                }
+                else {
+                    new Toast("Student already assigned to assessment.", Toast.TYPE_ERROR, Toast.TIME_NORMAL);
+                }
+            }
+            // Assign to core project
+            else {
+                assignStudentToProject(rawStudent, project)
+            }
         }
     }
 


### PR DESCRIPTION
When a student was assigned to the assessment for a book, and an instsructor in advertantly drag/drop the student back onto the assessment column, the student was being assigned to a project with that `id`. This resulted in students being assigned to projects in different courses, making them disappear from the UI.

Since assessments are given the index of 99 when being added to the array of projects, I check that index to either assign to assessment or project.